### PR TITLE
Rename cluster_version to kubectl_version, deprecate bitnami

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ module "cilium_cleanup_helper" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_backoff_limit"></a> [backoff\_limit](#input\_backoff\_limit) | Backoff limit for the job | `number` | `10` | no |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Version of kubernetes cluster, for matching kubectl image version | `string` | `"1.27"` | no |
+| <a name="input_kubectl_version"></a> [kubectl\_version](#input\_kubectl\_version) | kubectl image version | `string` | `"1.33.4"` | no |
 
 * * *
 <details>

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ when provisioning EKS cluster with Cilium.
 
 ```hcl
 module "cilium_cleanup_helper" {
-  source          = "github.com/lassizci/terraform-eks-cilium-helper?ref=v0.9"
-  cluster_version = "1.27"
+  source          = "github.com/lassizci/terraform-eks-cilium-helper?ref=v1.0"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "kubernetes_job" "this" {
         }
         container {
           name    = "kubectl"
-          image   = "bitnami/kubectl:${var.cluster_version}"
+          image   = "alpine/kubectl:${var.kubectl_version}"
           command = ["sh", "-c", "(kubectl -n kube-system delete daemonset/kube-proxy; kubectl -n kube-system delete daemonset aws-node) || true"]
         }
         restart_policy = "Never"

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
-variable "cluster_version" {
-  description = "Version of kubernetes cluster, for matching kubectl image version"
+variable "kubectl_version" {
+  description = "kubectl image version"
   type        = string
-  default     = "1.27"
+  default     = "1.33.4"
 }
 
 variable "backoff_limit" {


### PR DESCRIPTION
Bitnami kubectl image no longer exists. Replace it with alpine/kubectl, which doesn't necessarily have image version for each kubernetes version. Therefore it might make more sense to rename the variable too.